### PR TITLE
Fix collision offset

### DIFF
--- a/realsense2_description/urdf/_d435.urdf.xacro
+++ b/realsense2_description/urdf/_d435.urdf.xacro
@@ -74,7 +74,7 @@ aluminum peripherial evaluation case.
         </xacro:unless>     
       </visual>
       <collision>
-        <origin xyz="0 ${-d435_cam_depth_py} 0" rpy="0 0 0"/>
+        <origin xyz="-0.0085 ${-d435_cam_depth_py} 0" rpy="0 0 0"/>
         <geometry>
           <box size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}"/>
         </geometry>


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
Realsense d435のcollisionとvisualがずれていたためcollisionにオフセットを追加して位置合わせしました

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #5 

<!-- 変更の詳細 -->
## Detail
Before
![Screenshot from 2024-04-22 16-29-39](https://github.com/sbgisen/realsense-ros/assets/19720932/0efb6262-86ef-4b19-a13b-363b45b35ae9)

After
![Screenshot from 2024-04-22 20-04-57](https://github.com/sbgisen/realsense-ros/assets/19720932/eba4402b-5d13-427e-8a2a-0137be727b0b)
